### PR TITLE
fix: skip WSL2 detector on non-Linux platforms

### DIFF
--- a/src/env_doctor/cli.py
+++ b/src/env_doctor/cli.py
@@ -7,6 +7,7 @@ to the new detector-based system.
 import sys
 import os
 import argparse
+import platform 
 from .core.registry import DetectorRegistry
 from .core.detector import Status
 from .db import get_max_cuda_for_driver, get_install_command, DB_DATA
@@ -326,6 +327,11 @@ def debug_command():
         print(f"\n--- {name.upper().replace('_', ' ')} ---")
         try:
             detector = DetectorRegistry.get(name)
+            # CHECK if detector can run on this platform
+            if not detector.can_run():
+                print(f"Status: skipped (not applicable on {platform.system()})")
+                continue
+
             result = detector.detect()
             
             print(f"Status: {result.status.value}")


### PR DESCRIPTION
## Bug Description
The WSL2 detector was incorrectly running on Windows in `doctor debug` mode, showing:
```
--- WSL2 ---
Status: success
Version: native_linux
Metadata: {'environment': 'Native Linux'}
```

This was misleading since the system was actually Windows, not Linux.

## Root Cause
The `debug_command()` function wasn't checking `detector.can_run()` before executing detectors. While the WSL2 detector has a platform check (`can_run()` returns `False` on non-Linux), the debug command ignored it and ran the detector anyway.

## Fix
Added `can_run()` check to `debug_command()`:
```python
detector = DetectorRegistry.get(name)

# Check if detector can run on this platform
if not detector.can_run():
    print(f"Status: skipped (not applicable on {platform.system()})")
    continue
```

Also added missing `import platform` statement.

## After Fix
WSL2 detector now correctly shows on Windows:
```
--- WSL2 ---
Status: skipped (not applicable on Windows)
```

The detector only runs on Linux systems where it's actually applicable.