### PR TITLE
feat: add env-doctor wsl command for dedicated WSL diagnostics (#73)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "env-doctor"
-version = "0.2.4"
+version = "0.2.5"
 description = "A CLI tool to verify and fix AI/ML environment compatibility (Driver <-> CUDA <-> Wheels) with platform-specific installation guides."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/env_doctor/detectors/wsl2.py
+++ b/src/env_doctor/detectors/wsl2.py
@@ -9,25 +9,27 @@ from env_doctor.core import Detector, DetectionResult, Status, DetectorRegistry
 class WSL2Detector(Detector):
     """
     Detects Windows Subsystem for Linux 2 (WSL2) environment and validates GPU forwarding.
-    
+
     This detector identifies whether the current environment is:
     - Native Linux
-    - WSL1 (no CUDA support available)  
+    - WSL1 (no CUDA support available)
     - WSL2 (GPU forwarding support available)
-    
+
     For WSL2 environments, it validates proper GPU forwarding setup including:
     - Absence of internal NVIDIA drivers (which break GPU forwarding)
     - Presence of WSL2 CUDA libraries
     - Functional nvidia-smi command
-    
+
     Note: WSL1 does not support CUDA at all, so this detector will warn users
     to upgrade to WSL2 for any GPU computing needs.
     """
-    
+
+    WSL2_CUDA_LIB_PATH = "/usr/lib/wsl/lib/libcuda.so"
+
     def can_run(self) -> bool:
         """Check if this detector can run on the current platform."""
         return platform.system() == "Linux"
-    
+
     def _read_proc_version(self) -> str:
         """Read /proc/version file to determine kernel version."""
         try:
@@ -35,54 +37,67 @@ class WSL2Detector(Detector):
                 return f.read().strip()
         except Exception:
             return ""
-    
+
     def _detect_wsl2_environment(self) -> str:
         """Detect the type of WSL environment, focusing on WSL2 support."""
         version_info = self._read_proc_version()
-        
+
         if not version_info:
             return "native_linux"
-        
+
         version_lower = version_info.lower()
         if "microsoft" in version_lower:
             if "wsl2" in version_lower:
                 return "wsl2"
             else:
                 return "wsl1"
-        
+
         return "native_linux"
-    
+
     def _check_nvidia_smi(self) -> bool:
         """Check if nvidia-smi command works."""
         try:
             result = subprocess.run(
-                ["nvidia-smi"], 
-                capture_output=True, 
+                ["nvidia-smi"],
+                capture_output=True,
                 timeout=5
             )
             return result.returncode == 0
         except Exception:
             return False
-    
+
     def _check_wsl2_libcuda(self) -> bool:
         """Check if WSL2 CUDA library exists."""
-        return os.path.exists("/usr/lib/wsl/lib/libcuda.so")
-    
+        return os.path.exists(self.WSL2_CUDA_LIB_PATH)
+
     def _check_internal_nvidia_driver(self) -> bool:
         """Check if internal NVIDIA driver is installed in WSL."""
         return os.path.exists("/usr/lib/x86_64-linux-gnu/libnvidia-ml.so")
-    
+
+    def _extract_kernel_version(self, proc_version: str) -> str:
+        """Extract the kernel version string from /proc/version."""
+        # /proc/version format: "Linux version X.Y.Z-... (...)"
+        parts = proc_version.split()
+        if len(parts) >= 3:
+            return parts[2]
+        return "unknown"
+
     def detect(self) -> DetectionResult:
         """Detect WSL2 environment and GPU forwarding status."""
         env_type = self._detect_wsl2_environment()
         result = DetectionResult(component="wsl2", status=Status.SUCCESS)
         result.version = env_type
-        
+
+        # Store kernel version in metadata for all paths
+        proc_version = self._read_proc_version()
+        if proc_version:
+            result.metadata["kernel_version"] = self._extract_kernel_version(proc_version)
+
         # Native Linux path
         if env_type == "native_linux":
             result.metadata["environment"] = "Native Linux"
             return result
-        
+
         # WSL1 path - no CUDA support available
         if env_type == "wsl1":
             result.metadata["environment"] = "WSL1"
@@ -90,37 +105,43 @@ class WSL2Detector(Detector):
             result.recommendations.append("Upgrade to WSL2 for GPU/CUDA support")
             result.status = Status.ERROR
             return result
-        
+
         # WSL2 path - check GPU forwarding setup
         if env_type == "wsl2":
             result.metadata["environment"] = "WSL2"
-            
-            # Check for problematic internal NVIDIA driver
+            result.metadata["cuda_lib_path"] = self.WSL2_CUDA_LIB_PATH
+
+            # Run all checks and store results in metadata
             has_internal_driver = self._check_internal_nvidia_driver()
+            has_libcuda = self._check_wsl2_libcuda()
+            nvidia_smi_works = self._check_nvidia_smi()
+
+            result.metadata["has_internal_driver"] = has_internal_driver
+            result.metadata["has_libcuda"] = has_libcuda
+            result.metadata["nvidia_smi_works"] = nvidia_smi_works
+
+            # Check for problematic internal NVIDIA driver
             if has_internal_driver:
                 result.status = Status.ERROR
                 result.issues.append("NVIDIA driver installed inside WSL. This breaks GPU forwarding.")
                 result.recommendations.append("Run: sudo apt remove --purge nvidia-*")
-                return result
-            
+
             # Check for WSL2 CUDA library
-            has_libcuda = self._check_wsl2_libcuda()
             if not has_libcuda:
                 result.status = Status.ERROR
                 result.issues.append("Missing /usr/lib/wsl/lib/libcuda.so")
                 result.recommendations.append("Reinstall NVIDIA driver on Windows host")
-                return result
-            
+
             # Check nvidia-smi functionality
-            nvidia_smi_works = self._check_nvidia_smi()
             if not nvidia_smi_works:
                 result.status = Status.ERROR
                 result.issues.append("nvidia-smi command failed")
                 result.recommendations.append("Install NVIDIA driver on Windows (version 470.76 or newer)")
-                return result
-            
+
             # All checks passed
-            result.metadata["gpu_forwarding"] = "enabled"
+            if result.status == Status.SUCCESS:
+                result.metadata["gpu_forwarding"] = "enabled"
+
             return result
-        
+
         return result

--- a/src/env_doctor/mcp/server.py
+++ b/src/env_doctor/mcp/server.py
@@ -184,6 +184,19 @@ async def list_tools() -> list[Tool]:
             },
         ),
         Tool(
+            name="wsl_info",
+            description=(
+                "Get detailed WSL (Windows Subsystem for Linux) environment information "
+                "including: environment type (Native Linux / WSL1 / WSL2), kernel version, "
+                "GPU forwarding status, and diagnostic checklist for WSL2 CUDA support."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "required": [],
+            },
+        ),
+        Tool(
             name="cuda_install",
             description=(
                 "Get step-by-step CUDA Toolkit installation instructions tailored to the user's platform. "
@@ -246,6 +259,9 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
 
     elif name == "cudnn_info":
         result = tools.cudnn_info()
+
+    elif name == "wsl_info":
+        result = tools.wsl_info()
 
     elif name == "cuda_install":
         version = arguments.get("version")

--- a/src/env_doctor/mcp/tools.py
+++ b/src/env_doctor/mcp/tools.py
@@ -371,6 +371,40 @@ def cudnn_info() -> Dict[str, Any]:
         }
 
 
+def wsl_info() -> Dict[str, Any]:
+    """
+    Get detailed WSL environment information.
+
+    Returns:
+        Dict with WSL environment analysis including:
+        - detected: Whether detection completed
+        - version: Environment type (native_linux, wsl1, wsl2)
+        - metadata: Kernel version, GPU forwarding checklist results
+        - issues: List of detected issues
+        - recommendations: List of recommendations
+    """
+    from env_doctor.detectors import wsl2
+    from env_doctor.core.registry import DetectorRegistry
+
+    try:
+        detector = DetectorRegistry.get("wsl2")
+
+        if not detector.can_run():
+            return {
+                "detected": False,
+                "status": "skipped",
+                "reason": "WSL detector not supported on this platform (only runs on Linux)",
+            }
+
+        result = detector.detect()
+        return result.to_dict()
+    except Exception as e:
+        return {
+            "detected": False,
+            "error": str(e),
+        }
+
+
 def cuda_install(version: Optional[str] = None) -> Dict[str, Any]:
     """
     Get step-by-step CUDA Toolkit installation instructions.

--- a/tests/integration/test_cli_json.py
+++ b/tests/integration/test_cli_json.py
@@ -135,6 +135,29 @@ def test_cudnn_info_json_output():
         assert "detected" in data
 
 
+def test_wsl_json_output():
+    """Test wsl command with --json flag."""
+    result = subprocess.run(
+        [sys.executable, "-m", "env_doctor.cli", "wsl", "--json"],
+        capture_output=True,
+        text=True
+    )
+
+    # Should produce valid JSON (or error JSON if platform not supported)
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        pytest.fail(f"Output is not valid JSON: {e}\nOutput: {result.stdout}")
+
+    # Either a DetectionResult or an error
+    if "error" in data:
+        assert isinstance(data["error"], str)
+    else:
+        assert "component" in data
+        assert "status" in data
+        assert "detected" in data
+
+
 def test_scan_json_output():
     """Test scan command with --json flag."""
     result = subprocess.run(

--- a/tests/unit/test_wsl2_detector.py
+++ b/tests/unit/test_wsl2_detector.py
@@ -27,7 +27,7 @@ class TestWSL2Detector:
         """Test detection of native Linux environment."""
         detector = WSL2Detector()
         result = detector.detect()
-        
+
         assert result.version == "native_linux"
         assert result.status == Status.SUCCESS
         assert result.metadata["environment"] == "Native Linux"
@@ -40,7 +40,7 @@ class TestWSL2Detector:
         """Test basic WSL2 detection with successful GPU forwarding."""
         detector = WSL2Detector()
         result = detector.detect()
-        
+
         assert result.version == "wsl2"
         assert result.status == Status.SUCCESS
         assert result.metadata["environment"] == "WSL2"
@@ -51,7 +51,7 @@ class TestWSL2Detector:
         """Test WSL1 detection and warning status."""
         detector = WSL2Detector()
         result = detector.detect()
-        
+
         assert result.version == "wsl1"
         assert result.status == Status.ERROR
         assert result.metadata["environment"] == "WSL1"
@@ -60,23 +60,30 @@ class TestWSL2Detector:
 
     @patch("builtins.open", mock_open(read_data="Linux version 5.10.0-microsoft-standard-WSL2"))
     @patch.object(WSL2Detector, "_check_internal_nvidia_driver", return_value=True)
-    def test_wsl2_internal_driver_error(self, mock_internal_driver):
+    @patch.object(WSL2Detector, "_check_wsl2_libcuda", return_value=True)
+    @patch.object(WSL2Detector, "_check_nvidia_smi", return_value=True)
+    def test_wsl2_internal_driver_error(self, mock_nvidia_smi, mock_libcuda, mock_internal_driver):
         """Test WSL2 with internal NVIDIA driver error."""
         detector = WSL2Detector()
         result = detector.detect()
-        
+
         assert result.status == Status.ERROR
         assert "NVIDIA driver installed inside WSL" in result.issues[0]
         assert "apt remove --purge nvidia-*" in result.recommendations[0]
+        # Metadata should still be populated
+        assert result.metadata["has_internal_driver"] is True
+        assert result.metadata["has_libcuda"] is True
+        assert result.metadata["nvidia_smi_works"] is True
 
     @patch("builtins.open", mock_open(read_data="Linux version 5.10.0-microsoft-standard-WSL2"))
     @patch.object(WSL2Detector, "_check_internal_nvidia_driver", return_value=False)
     @patch.object(WSL2Detector, "_check_wsl2_libcuda", return_value=False)
-    def test_wsl2_missing_libcuda(self, mock_libcuda, mock_internal_driver):
+    @patch.object(WSL2Detector, "_check_nvidia_smi", return_value=True)
+    def test_wsl2_missing_libcuda(self, mock_nvidia_smi, mock_libcuda, mock_internal_driver):
         """Test WSL2 with missing libcuda error."""
         detector = WSL2Detector()
         result = detector.detect()
-        
+
         assert result.status == Status.ERROR
         assert "Missing /usr/lib/wsl/lib/libcuda.so" in result.issues[0]
         assert "Reinstall NVIDIA driver on Windows" in result.recommendations[0]
@@ -89,7 +96,7 @@ class TestWSL2Detector:
         """Test WSL2 with nvidia-smi failure error."""
         detector = WSL2Detector()
         result = detector.detect()
-        
+
         assert result.status == Status.ERROR
         assert "nvidia-smi command failed" in result.issues[0]
         assert "Install NVIDIA driver on Windows" in result.recommendations[0]
@@ -104,19 +111,19 @@ class TestWSL2Detector:
     def test_detect_wsl2_environment_edge_cases(self):
         """Test _detect_wsl2_environment with various version strings."""
         detector = WSL2Detector()
-        
+
         # Test empty version
         with patch.object(detector, "_read_proc_version", return_value=""):
             assert detector._detect_wsl2_environment() == "native_linux"
-        
+
         # Test microsoft without WSL2
         with patch.object(detector, "_read_proc_version", return_value="Linux version 4.4.0-microsoft"):
             assert detector._detect_wsl2_environment() == "wsl1"
-        
+
         # Test microsoft with WSL2
         with patch.object(detector, "_read_proc_version", return_value="Linux version 5.10.0-microsoft-standard-WSL2"):
             assert detector._detect_wsl2_environment() == "wsl2"
-        
+
         # Test non-microsoft
         with patch.object(detector, "_read_proc_version", return_value="Linux version 5.10.0-generic"):
             assert detector._detect_wsl2_environment() == "native_linux"
@@ -164,3 +171,78 @@ class TestWSL2Detector:
         detector = WSL2Detector()
         with patch("env_doctor.detectors.wsl2.os.path.exists", return_value=False):
             assert detector._check_internal_nvidia_driver() is False
+
+
+class TestWSL2DetectorEnhancedMetadata:
+    """Tests for the enhanced metadata fields."""
+
+    @patch("builtins.open", mock_open(read_data="Linux version 5.10.0-microsoft-standard-WSL2 (gcc)"))
+    @patch.object(WSL2Detector, "_check_internal_nvidia_driver", return_value=False)
+    @patch.object(WSL2Detector, "_check_wsl2_libcuda", return_value=True)
+    @patch.object(WSL2Detector, "_check_nvidia_smi", return_value=True)
+    def test_wsl2_metadata_includes_kernel_version(self, mock_smi, mock_lib, mock_drv):
+        """Test that WSL2 detection includes kernel version in metadata."""
+        detector = WSL2Detector()
+        result = detector.detect()
+
+        assert "kernel_version" in result.metadata
+        assert result.metadata["kernel_version"] == "5.10.0-microsoft-standard-WSL2"
+
+    @patch("builtins.open", mock_open(read_data="Linux version 5.10.0-microsoft-standard-WSL2 (gcc)"))
+    @patch.object(WSL2Detector, "_check_internal_nvidia_driver", return_value=False)
+    @patch.object(WSL2Detector, "_check_wsl2_libcuda", return_value=True)
+    @patch.object(WSL2Detector, "_check_nvidia_smi", return_value=True)
+    def test_wsl2_metadata_includes_check_results(self, mock_smi, mock_lib, mock_drv):
+        """Test that WSL2 detection stores all check results in metadata."""
+        detector = WSL2Detector()
+        result = detector.detect()
+
+        assert result.metadata["has_internal_driver"] is False
+        assert result.metadata["has_libcuda"] is True
+        assert result.metadata["nvidia_smi_works"] is True
+        assert result.metadata["cuda_lib_path"] == "/usr/lib/wsl/lib/libcuda.so"
+
+    @patch("builtins.open", mock_open(read_data="Linux version 5.10.0-microsoft-standard-WSL2 (gcc)"))
+    @patch.object(WSL2Detector, "_check_internal_nvidia_driver", return_value=True)
+    @patch.object(WSL2Detector, "_check_wsl2_libcuda", return_value=False)
+    @patch.object(WSL2Detector, "_check_nvidia_smi", return_value=False)
+    def test_wsl2_all_checks_fail_metadata_still_populated(self, mock_smi, mock_lib, mock_drv):
+        """Test that metadata is populated even when all checks fail."""
+        detector = WSL2Detector()
+        result = detector.detect()
+
+        assert result.status == Status.ERROR
+        assert result.metadata["has_internal_driver"] is True
+        assert result.metadata["has_libcuda"] is False
+        assert result.metadata["nvidia_smi_works"] is False
+        # All three issues should be reported
+        assert len(result.issues) == 3
+        assert len(result.recommendations) == 3
+
+    @patch("builtins.open", mock_open(read_data="Linux version 4.4.0-microsoft"))
+    def test_wsl1_metadata_includes_kernel_version(self):
+        """Test that WSL1 detection includes kernel version."""
+        detector = WSL2Detector()
+        result = detector.detect()
+
+        assert "kernel_version" in result.metadata
+        assert result.metadata["kernel_version"] == "4.4.0-microsoft"
+
+    @patch("builtins.open", mock_open(read_data="Linux version 5.15.0-generic (gcc)"))
+    def test_native_linux_metadata_includes_kernel_version(self):
+        """Test that native Linux detection includes kernel version."""
+        detector = WSL2Detector()
+        result = detector.detect()
+
+        assert result.version == "native_linux"
+        assert "kernel_version" in result.metadata
+        assert result.metadata["kernel_version"] == "5.15.0-generic"
+
+    def test_extract_kernel_version(self):
+        """Test kernel version extraction from proc version strings."""
+        detector = WSL2Detector()
+
+        assert detector._extract_kernel_version("Linux version 5.10.0-microsoft-standard-WSL2 (gcc)") == "5.10.0-microsoft-standard-WSL2"
+        assert detector._extract_kernel_version("Linux version 5.15.0-generic") == "5.15.0-generic"
+        assert detector._extract_kernel_version("short") == "unknown"
+        assert detector._extract_kernel_version("") == "unknown"


### PR DESCRIPTION
Adds a dedicated `env-doctor wsl` command (and MCP tool `wsl_info`) that gives WSL2 users a single command to diagnose their GPU forwarding setup, following the same pattern as `cudnn-info` and `cuda-info`.

Changes:
- WSL2Detector: enriched metadata with kernel version, cuda_lib_path, and all three check results (has_internal_driver, has_libcuda, nvidia_smi_works) stored even on failure, enabling full post-run diagnostics
- cli.py: added `wsl` subcommand with `--json` flag, `wsl_info_command()` dispatcher, and `print_wsl_detailed_info()` pretty-printer with GPU forwarding checklist
- mcp/server.py: added `wsl_info` Tool definition
- mcp/tools.py: added `wsl_info()` wrapper function
- tests: expanded WSL2 unit tests with 6 new metadata assertions; added `test_wsl_json_output` integration test
- pyproject.toml: bump version to 0.2.5