### PR TITLE
fix: remove huggingface_hub upper version cap

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "click>=8.0.0,<9.0.0",
     "requests>=2.25.0,<3.0.0",
     "pyyaml>=5.4,<7.0",
-    "huggingface_hub>=0.20.0,<1.0.0",
+    "huggingface_hub>=0.20.0",
     "mcp>=1.0.0,<2.0.0",
 ]
 


### PR DESCRIPTION
The <1.0.0 cap forced pip to downgrade to 0.x, causing conflicts in modern ML projects where huggingface_hub>=1.x is standard.

APIs used (model_info, HfApi, RepositoryNotFoundError, HfHubHTTPError) are stable in 1.x. Verified all 70 tests pass on huggingface_hub 1.5.0.




  Fix: Remove huggingface_hub upper version cap

  File changed: pyproject.toml

  - "huggingface_hub>=0.20.0,<1.0.0",
  + "huggingface_hub>=0.20.0",

  Problem

  The <1.0.0 cap forced pip to downgrade huggingface_hub to 0.x, causing conflicts in modern ML projects where huggingface_hub>=1.x is standard.

  Verification

  - All 4 APIs used (model_info, HfApi, RepositoryNotFoundError, HfHubHTTPError) confirmed available in huggingface_hub==1.5.0 (latest)
  - 70/70 tests pass on both 0.25.1 and 1.5.0


#65 fixed