### PR TITLE
feat: add --recommend flag to env-doctor model command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to env-doctor will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **`--recommend` flag for `env-doctor model`**: Suggests cloud GPU instances (AWS, GCP, Azure) sorted by cost when a model doesn't fit locally
+- **`--vram` flag**: Direct VRAM-based cloud instance lookup without specifying a model name (`env-doctor model --vram 80000 --recommend`)
+- **`cloud_instances.json`**: Static data file covering 17 GPU instances across AWS, GCP, and Azure
+- **Cloud recommendations via MCP**: `model_check` tool accepts `recommend` boolean to include cloud instance suggestions in results
+
 ## [0.2.8] - 2026-03-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -383,6 +383,25 @@ env-doctor model llama-3-8b
 
 List all models: `env-doctor model --list`
 
+**Cloud GPU Recommendations:**
+
+```bash
+# Get cloud GPU recommendations for a model that doesn't fit
+env-doctor model llama-3-70b --recommend
+
+# Direct VRAM lookup (no model name needed)
+env-doctor model --vram 80000 --recommend
+```
+
+```
+☁️   Cloud GPU Recommendations
+
+  FP16 (~140.0 GB):
+    $27.20 /hr  azure  ND96asr_v4              8x A100 (40GB each)          180.0GB free
+    $29.39 /hr  gcp    a2-highgpu-8g            8x A100 (40GB each)          180.0GB free
+    ...
+```
+
 Automatic HuggingFace Support (New ✨)
 If a model isn't found locally, env-doctor automatically checks the HuggingFace Hub, fetches its parameter metadata, and caches it locally for future runs — no manual setup required.
 

--- a/docs/commands/model.md
+++ b/docs/commands/model.md
@@ -14,6 +14,8 @@ env-doctor model <model-name>
 |--------|-------------|
 | `--list` | List all available models in local database |
 | `--precision <type>` | Check specific precision (fp32, fp16, bf16, int8, int4, fp8) |
+| `--recommend` | Show cloud GPU instance recommendations (AWS, GCP, Azure) sorted by cost |
+| `--vram <MB>` | Direct VRAM requirement in MB (use with `--recommend`, without model name) |
 
 ## Example
 
@@ -219,6 +221,48 @@ env-doctor model llama-3-70b
 2. Use INT4 quantization with 2x RTX 3090
 3. Consider cloud GPU (A100 80GB)
 ```
+
+## Cloud GPU Recommendations
+
+When a model doesn't fit on your local GPU (or you're planning a cloud deployment), use `--recommend` to see cloud GPU instance suggestions:
+
+```bash
+env-doctor model llama-3-70b --recommend
+```
+
+**Output:**
+
+```
+☁️   Cloud GPU Recommendations
+============================================================
+
+  FP16 (~140.0 GB):
+    $27.20 /hr  azure  ND96asr_v4              8x A100 (40GB each)          180.0GB free
+    $29.39 /hr  gcp    a2-highgpu-8g            8x A100 (40GB each)          180.0GB free
+    $32.77 /hr  aws    p4d.24xlarge             8x A100 (40GB each)          180.0GB free
+
+  INT4 (~35.0 GB):
+    $3.67  /hr  gcp    a2-highgpu-1g            1x A100 (40GB)               5.0GB free
+    $3.67  /hr  azure  NC24ads_A100_v4          1x A100 (80GB)               45.0GB free
+
+  Sorted by cost (cheapest first). Prices are approximate on-demand rates.
+============================================================
+```
+
+Instances are shown per quantization level, sorted by cost (cheapest first), covering AWS, GCP, and Azure.
+
+### Direct VRAM Lookup
+
+If you know the VRAM requirement but aren't checking a specific model, use `--vram`:
+
+```bash
+env-doctor model --vram 80000 --recommend
+```
+
+This shows all cloud instances with at least 80GB of GPU VRAM, sorted by price.
+
+!!! note "Pricing"
+    All prices shown are approximate on-demand rates from public cloud provider pages and may not reflect current pricing, spot/preemptible discounts, or reserved instance rates.
 
 ## How VRAM Is Calculated
 

--- a/src/env_doctor/cli.py
+++ b/src/env_doctor/cli.py
@@ -1641,16 +1641,17 @@ def _print_validation_result(result):
         print("\n⚠️   Validation passed with warnings. Review before deploying.")
     else:
         print("\n✅  All checks passed!")
-def model_command(model_name: str, precision: str = None):
+def model_command(model_name: str, precision: str = None, recommend: bool = False):
     """
     Check if a model can run on available hardware.
 
     Args:
         model_name: Name of the model to check
         precision: Optional specific precision to check
+        recommend: Whether to show cloud GPU recommendations
     """
     checker = ModelChecker()
-    result = checker.check_compatibility(model_name, precision)
+    result = checker.check_compatibility(model_name, precision, recommend=recommend)
 
     if not result["success"]:
         print(f"\n❌  {result['error']}")
@@ -1753,12 +1754,89 @@ def print_model_compatibility(result: dict):
             print(f"{i}. {rec}")
         print()
 
+    # Cloud Recommendations
+    cloud_recs = result.get("cloud_recommendations")
+    if cloud_recs:
+        print_cloud_recommendations(cloud_recs)
+
     # Reference
     if model_info.get("hf_id"):
         print("=" * 60)
         print("📚  Reference:")
         print(f"    https://huggingface.co/{model_info['hf_id']}")
         print("=" * 60)
+
+
+def print_cloud_recommendations(cloud_recs: dict):
+    """
+    Print cloud GPU recommendations table.
+
+    Args:
+        cloud_recs: Dict mapping precision to {vram_gb, instances}
+    """
+    print("=" * 60)
+    print("☁️   Cloud GPU Recommendations")
+    print("=" * 60)
+
+    precision_order = ["fp16", "bf16", "fp32", "int8", "int4", "fp8"]
+    for precision in precision_order:
+        if precision not in cloud_recs:
+            continue
+
+        info = cloud_recs[precision]
+        vram_gb = info["vram_gb"]
+        instances = info["instances"]
+
+        print(f"\n  {precision.upper()} (~{vram_gb} GB):")
+
+        if not instances:
+            print("    No matching instances found")
+            continue
+
+        for inst in instances:
+            print(
+                f"    ${inst['approx_cost_hr']:<7.2f}/hr  "
+                f"{inst['provider']:<5s}  "
+                f"{inst['name']:<22s}  "
+                f"{inst['gpu_summary']:<28s}  "
+                f"{inst['headroom_gb']}GB free"
+            )
+
+    print(f"\n  Sorted by cost (cheapest first). Prices are approximate on-demand rates.")
+    print("=" * 60 + "\n")
+
+
+def recommend_by_vram(vram_mb: int):
+    """
+    Show cloud GPU recommendations for a given VRAM requirement.
+
+    Args:
+        vram_mb: Required VRAM in megabytes
+    """
+    from env_doctor.utilities.cloud_recommender import CloudRecommender
+
+    recommender = CloudRecommender()
+    instances = recommender.recommend(vram_mb)
+    vram_gb = round(vram_mb / 1024, 1)
+
+    print(f"\n☁️   Cloud GPU Recommendations for {vram_gb} GB VRAM")
+    print("=" * 60)
+
+    if not instances:
+        print("\n  No matching instances found for this VRAM requirement.\n")
+        return
+
+    for inst in instances[:10]:
+        print(
+            f"  ${inst['approx_cost_hr']:<7.2f}/hr  "
+            f"{inst['provider']:<5s}  "
+            f"{inst['name']:<22s}  "
+            f"{inst['gpu_summary']:<28s}  "
+            f"{inst['headroom_gb']}GB free"
+        )
+
+    print(f"\n  Sorted by cost (cheapest first). Prices are approximate on-demand rates.")
+    print("=" * 60 + "\n")
 
 
 def list_models_command():
@@ -2313,6 +2391,17 @@ Examples:
         action="store_true",
         help="List all available models"
     )
+    model_p.add_argument(
+        "--recommend",
+        action="store_true",
+        help="Show cloud GPU instance recommendations (AWS, GCP, Azure)"
+    )
+    model_p.add_argument(
+        "--vram",
+        type=int,
+        metavar="MB",
+        help="Direct VRAM requirement in MB (use with --recommend, without model_name)"
+    )
 
     # Export command
     export_p = subparsers.add_parser(
@@ -2384,8 +2473,10 @@ Examples:
     elif args.command == "model":
         if args.list:
             list_models_command()
+        elif getattr(args, 'vram', None) and getattr(args, 'recommend', False):
+            recommend_by_vram(args.vram)
         elif args.model_name:
-            model_command(args.model_name, args.precision)
+            model_command(args.model_name, args.precision, recommend=getattr(args, 'recommend', False))
         else:
             model_p.print_help()
     elif args.command == "install":

--- a/src/env_doctor/data/cloud_instances.json
+++ b/src/env_doctor/data/cloud_instances.json
@@ -1,0 +1,127 @@
+{
+  "_metadata": {
+    "last_updated": "2026-03-25",
+    "note": "Approximate on-demand pricing from public cloud provider pages"
+  },
+  "instances": [
+    {
+      "provider": "aws",
+      "name": "g5.xlarge",
+      "gpus": [{ "model": "A10G", "count": 1, "vram_gb": 24 }],
+      "total_vram_gb": 24,
+      "approx_cost_hr": 1.006
+    },
+    {
+      "provider": "aws",
+      "name": "g5.12xlarge",
+      "gpus": [{ "model": "A10G", "count": 4, "vram_gb": 24 }],
+      "total_vram_gb": 96,
+      "approx_cost_hr": 5.672
+    },
+    {
+      "provider": "aws",
+      "name": "p3.2xlarge",
+      "gpus": [{ "model": "V100", "count": 1, "vram_gb": 16 }],
+      "total_vram_gb": 16,
+      "approx_cost_hr": 3.06
+    },
+    {
+      "provider": "aws",
+      "name": "p3.8xlarge",
+      "gpus": [{ "model": "V100", "count": 4, "vram_gb": 16 }],
+      "total_vram_gb": 64,
+      "approx_cost_hr": 12.24
+    },
+    {
+      "provider": "aws",
+      "name": "p3.16xlarge",
+      "gpus": [{ "model": "V100", "count": 8, "vram_gb": 16 }],
+      "total_vram_gb": 128,
+      "approx_cost_hr": 24.48
+    },
+    {
+      "provider": "aws",
+      "name": "p4d.24xlarge",
+      "gpus": [{ "model": "A100", "count": 8, "vram_gb": 40 }],
+      "total_vram_gb": 320,
+      "approx_cost_hr": 32.77
+    },
+    {
+      "provider": "aws",
+      "name": "p5.48xlarge",
+      "gpus": [{ "model": "H100", "count": 8, "vram_gb": 80 }],
+      "total_vram_gb": 640,
+      "approx_cost_hr": 98.32
+    },
+    {
+      "provider": "gcp",
+      "name": "g2-standard-4",
+      "gpus": [{ "model": "L4", "count": 1, "vram_gb": 24 }],
+      "total_vram_gb": 24,
+      "approx_cost_hr": 0.70
+    },
+    {
+      "provider": "gcp",
+      "name": "g2-standard-48",
+      "gpus": [{ "model": "L4", "count": 4, "vram_gb": 24 }],
+      "total_vram_gb": 96,
+      "approx_cost_hr": 5.44
+    },
+    {
+      "provider": "gcp",
+      "name": "a2-highgpu-1g",
+      "gpus": [{ "model": "A100", "count": 1, "vram_gb": 40 }],
+      "total_vram_gb": 40,
+      "approx_cost_hr": 3.67
+    },
+    {
+      "provider": "gcp",
+      "name": "a2-highgpu-8g",
+      "gpus": [{ "model": "A100", "count": 8, "vram_gb": 40 }],
+      "total_vram_gb": 320,
+      "approx_cost_hr": 29.39
+    },
+    {
+      "provider": "gcp",
+      "name": "a3-highgpu-8g",
+      "gpus": [{ "model": "H100", "count": 8, "vram_gb": 80 }],
+      "total_vram_gb": 640,
+      "approx_cost_hr": 101.22
+    },
+    {
+      "provider": "azure",
+      "name": "NC6s_v3",
+      "gpus": [{ "model": "V100", "count": 1, "vram_gb": 16 }],
+      "total_vram_gb": 16,
+      "approx_cost_hr": 3.06
+    },
+    {
+      "provider": "azure",
+      "name": "NC24s_v3",
+      "gpus": [{ "model": "V100", "count": 4, "vram_gb": 16 }],
+      "total_vram_gb": 64,
+      "approx_cost_hr": 12.24
+    },
+    {
+      "provider": "azure",
+      "name": "NC24ads_A100_v4",
+      "gpus": [{ "model": "A100", "count": 1, "vram_gb": 80 }],
+      "total_vram_gb": 80,
+      "approx_cost_hr": 3.67
+    },
+    {
+      "provider": "azure",
+      "name": "ND96asr_v4",
+      "gpus": [{ "model": "A100", "count": 8, "vram_gb": 40 }],
+      "total_vram_gb": 320,
+      "approx_cost_hr": 27.20
+    },
+    {
+      "provider": "azure",
+      "name": "ND96amsr_A100_v4",
+      "gpus": [{ "model": "A100", "count": 8, "vram_gb": 80 }],
+      "total_vram_gb": 640,
+      "approx_cost_hr": 32.77
+    }
+  ]
+}

--- a/src/env_doctor/mcp/server.py
+++ b/src/env_doctor/mcp/server.py
@@ -71,6 +71,10 @@ async def list_tools() -> list[Tool]:
                         "description": "Optional specific precision to check",
                         "enum": ["fp32", "fp16", "bf16", "int8", "int4", "fp8"],
                     },
+                    "recommend": {
+                        "type": "boolean",
+                        "description": "Include cloud GPU instance recommendations (AWS, GCP, Azure) sorted by cost",
+                    },
                 },
                 "required": ["model_name"],
             },
@@ -234,7 +238,8 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
     elif name == "model_check":
         model_name = arguments.get("model_name", "")
         precision = arguments.get("precision")
-        result = tools.model_check(model_name, precision)
+        recommend = arguments.get("recommend", False)
+        result = tools.model_check(model_name, precision, recommend)
 
     elif name == "model_list":
         result = tools.model_list()

--- a/src/env_doctor/mcp/tools.py
+++ b/src/env_doctor/mcp/tools.py
@@ -108,13 +108,14 @@ def env_check_component(component: str) -> Dict[str, Any]:
         }
 
 
-def model_check(model_name: str, precision: Optional[str] = None) -> Dict[str, Any]:
+def model_check(model_name: str, precision: Optional[str] = None, recommend: bool = False) -> Dict[str, Any]:
     """
     Check if an AI model fits on available GPU hardware.
 
     Args:
         model_name: Name of the model (e.g., "llama-3-8b", "meta-llama/Llama-2-7b-hf")
         precision: Optional precision level (fp32, fp16, bf16, int8, int4, fp8)
+        recommend: Whether to include cloud GPU instance recommendations
 
     Returns:
         Dict with model compatibility analysis including:
@@ -124,6 +125,7 @@ def model_check(model_name: str, precision: Optional[str] = None) -> Dict[str, A
         - vram_requirements: VRAM needed for each precision
         - compatibility: Which precisions fit on GPU
         - recommendations: Actionable recommendations
+        - cloud_recommendations: Cloud GPU suggestions (if recommend=True)
     """
     # Import detectors to trigger registration (needed by ModelChecker)
     from env_doctor.detectors import nvidia_driver
@@ -131,7 +133,7 @@ def model_check(model_name: str, precision: Optional[str] = None) -> Dict[str, A
 
     try:
         checker = ModelChecker()
-        result = checker.check_compatibility(model_name, precision)
+        result = checker.check_compatibility(model_name, precision, recommend=recommend)
         return result
     except Exception as e:
         return {

--- a/src/env_doctor/utilities/cloud_recommender.py
+++ b/src/env_doctor/utilities/cloud_recommender.py
@@ -1,0 +1,89 @@
+"""
+Cloud GPU instance recommender.
+
+Suggests cloud GPU instances (AWS, GCP, Azure) based on VRAM requirements,
+sorted by cost.
+"""
+
+import json
+import os
+from typing import Any, Dict, List
+
+
+class CloudRecommender:
+    """Recommend cloud GPU instances based on VRAM requirements."""
+
+    def __init__(self):
+        """Load cloud instance data from JSON."""
+        data_path = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            "data",
+            "cloud_instances.json",
+        )
+        with open(data_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        self.instances = data["instances"]
+
+    def recommend(self, vram_mb: int) -> List[Dict[str, Any]]:
+        """
+        Return instances where total_vram_gb >= vram_mb/1024,
+        sorted by approx_cost_hr ascending (cheapest first).
+
+        Args:
+            vram_mb: Required VRAM in megabytes
+
+        Returns:
+            List of instance dicts with provider, name, gpu_summary,
+            total_vram_gb, approx_cost_hr, and headroom_gb.
+        """
+        required_gb = vram_mb / 1024
+        results = []
+
+        for inst in self.instances:
+            if inst["total_vram_gb"] >= required_gb:
+                gpu = inst["gpus"][0]
+                if gpu["count"] == 1:
+                    gpu_summary = f"1x {gpu['model']} ({gpu['vram_gb']}GB)"
+                else:
+                    gpu_summary = f"{gpu['count']}x {gpu['model']} ({gpu['vram_gb']}GB each)"
+
+                results.append({
+                    "provider": inst["provider"],
+                    "name": inst["name"],
+                    "gpu_summary": gpu_summary,
+                    "total_vram_gb": inst["total_vram_gb"],
+                    "approx_cost_hr": inst["approx_cost_hr"],
+                    "headroom_gb": round(inst["total_vram_gb"] - required_gb, 1),
+                })
+
+        results.sort(key=lambda x: x["approx_cost_hr"])
+        return results
+
+    def recommend_for_model(self, vram_requirements: Dict[str, Dict]) -> Dict[str, Any]:
+        """
+        Given vram_requirements dict (precision -> {vram_mb, ...}),
+        return recommendations per quantization level.
+
+        Args:
+            vram_requirements: Dict mapping precision to requirement info
+                (must contain 'vram_mb' key)
+
+        Returns:
+            Dict mapping precision to {vram_gb, instances} where instances
+            is limited to top 5 cheapest. Only includes precisions where
+            VRAM > 0.
+        """
+        result = {}
+
+        for precision, req_info in vram_requirements.items():
+            vram_mb = req_info.get("vram_mb", 0)
+            if vram_mb <= 0:
+                continue
+
+            instances = self.recommend(vram_mb)
+            result[precision] = {
+                "vram_gb": round(vram_mb / 1024, 1),
+                "instances": instances[:5],
+            }
+
+        return result

--- a/src/env_doctor/utilities/model_checker.py
+++ b/src/env_doctor/utilities/model_checker.py
@@ -18,7 +18,8 @@ class ModelChecker:
         self.vram_calc = VRAMCalculator()
 
     def check_compatibility(
-        self, model_name: str, precision: Optional[str] = None, _depth: int = 0
+        self, model_name: str, precision: Optional[str] = None, _depth: int = 0,
+        recommend: bool = False,
     ) -> Dict[str, Any]:
         """
         Check if model is compatible with available hardware.
@@ -81,7 +82,7 @@ class ModelChecker:
             normalized_name, model_info, vram_reqs, gpu_info, compatibility, _depth=_depth
         )
 
-        return {
+        result = {
             "success": True,
             "model_name": normalized_name,
             "model_info": model_info,
@@ -91,6 +92,13 @@ class ModelChecker:
             "recommendations": recommendations,
             "fetched_from_hf": fetched_from_hf,
         }
+
+        if recommend:
+            from env_doctor.utilities.cloud_recommender import CloudRecommender
+            recommender = CloudRecommender()
+            result["cloud_recommendations"] = recommender.recommend_for_model(vram_reqs)
+
+        return result
 
     def _get_gpu_info(self) -> Dict[str, Any]:
         """

--- a/tests/unit/utilities/test_cloud_recommender.py
+++ b/tests/unit/utilities/test_cloud_recommender.py
@@ -1,0 +1,138 @@
+"""Tests for CloudRecommender utility."""
+
+import pytest
+from env_doctor.utilities.cloud_recommender import CloudRecommender
+
+
+@pytest.fixture
+def recommender():
+    """Create a CloudRecommender instance."""
+    return CloudRecommender()
+
+
+class TestCloudRecommenderInit:
+    """Tests for CloudRecommender initialization."""
+
+    def test_loads_instances(self, recommender):
+        """Should load cloud instances from JSON."""
+        assert len(recommender.instances) > 0
+
+    def test_instances_have_required_fields(self, recommender):
+        """Each instance should have provider, name, gpus, total_vram_gb, approx_cost_hr."""
+        for inst in recommender.instances:
+            assert "provider" in inst
+            assert "name" in inst
+            assert "gpus" in inst
+            assert "total_vram_gb" in inst
+            assert "approx_cost_hr" in inst
+
+
+class TestRecommend:
+    """Tests for recommend() method."""
+
+    def test_returns_sorted_by_cost(self, recommender):
+        """Results should be sorted by approx_cost_hr ascending."""
+        results = recommender.recommend(16 * 1024)  # 16GB
+        costs = [r["approx_cost_hr"] for r in results]
+        assert costs == sorted(costs)
+
+    def test_filters_insufficient_vram(self, recommender):
+        """Should only return instances with enough total VRAM."""
+        vram_mb = 80 * 1024  # 80GB
+        results = recommender.recommend(vram_mb)
+        for r in results:
+            assert r["total_vram_gb"] >= 80
+
+    def test_small_vram_returns_many(self, recommender):
+        """Small VRAM requirement should return many instances."""
+        results = recommender.recommend(1 * 1024)  # 1GB
+        assert len(results) > 5
+
+    def test_very_high_vram_returns_empty(self, recommender):
+        """VRAM beyond any instance should return empty list."""
+        results = recommender.recommend(10_000 * 1024)  # 10TB
+        assert results == []
+
+    def test_headroom_calculation(self, recommender):
+        """Headroom should be total_vram_gb minus required GB."""
+        vram_mb = 20 * 1024  # 20GB
+        results = recommender.recommend(vram_mb)
+        for r in results:
+            expected_headroom = round(r["total_vram_gb"] - 20.0, 1)
+            assert r["headroom_gb"] == expected_headroom
+
+    def test_result_has_required_keys(self, recommender):
+        """Each result should have all expected keys."""
+        results = recommender.recommend(16 * 1024)
+        assert len(results) > 0
+        for r in results:
+            assert "provider" in r
+            assert "name" in r
+            assert "gpu_summary" in r
+            assert "total_vram_gb" in r
+            assert "approx_cost_hr" in r
+            assert "headroom_gb" in r
+
+    def test_gpu_summary_format_single(self, recommender):
+        """Single-GPU instances should show '1x MODEL (XGB)'."""
+        results = recommender.recommend(1 * 1024)
+        single_gpu = [r for r in results if r["gpu_summary"].startswith("1x")]
+        assert len(single_gpu) > 0
+        for r in single_gpu:
+            assert "1x " in r["gpu_summary"]
+            assert "GB)" in r["gpu_summary"]
+
+    def test_gpu_summary_format_multi(self, recommender):
+        """Multi-GPU instances should show 'Nx MODEL (XGB each)'."""
+        results = recommender.recommend(100 * 1024)  # need multi-GPU
+        multi_gpu = [r for r in results if not r["gpu_summary"].startswith("1x")]
+        assert len(multi_gpu) > 0
+        for r in multi_gpu:
+            assert "each)" in r["gpu_summary"]
+
+
+class TestRecommendForModel:
+    """Tests for recommend_for_model() method."""
+
+    def test_returns_per_precision(self, recommender):
+        """Should return recommendations for each precision."""
+        vram_reqs = {
+            "fp16": {"vram_mb": 19200},
+            "int8": {"vram_mb": 9600},
+            "int4": {"vram_mb": 4800},
+        }
+        result = recommender.recommend_for_model(vram_reqs)
+        assert "fp16" in result
+        assert "int8" in result
+        assert "int4" in result
+
+    def test_each_precision_has_vram_gb_and_instances(self, recommender):
+        """Each precision entry should have vram_gb and instances."""
+        vram_reqs = {"fp16": {"vram_mb": 19200}}
+        result = recommender.recommend_for_model(vram_reqs)
+        assert "vram_gb" in result["fp16"]
+        assert "instances" in result["fp16"]
+        assert result["fp16"]["vram_gb"] == round(19200 / 1024, 1)
+
+    def test_limits_to_top_5(self, recommender):
+        """Should return at most 5 instances per precision."""
+        vram_reqs = {"int4": {"vram_mb": 1024}}  # 1GB - many match
+        result = recommender.recommend_for_model(vram_reqs)
+        assert len(result["int4"]["instances"]) <= 5
+
+    def test_skips_zero_vram(self, recommender):
+        """Should skip precisions with vram_mb <= 0."""
+        vram_reqs = {
+            "fp16": {"vram_mb": 19200},
+            "broken": {"vram_mb": 0},
+        }
+        result = recommender.recommend_for_model(vram_reqs)
+        assert "fp16" in result
+        assert "broken" not in result
+
+    def test_instances_sorted_by_cost(self, recommender):
+        """Instances within each precision should be sorted by cost."""
+        vram_reqs = {"fp16": {"vram_mb": 19200}}
+        result = recommender.recommend_for_model(vram_reqs)
+        costs = [i["approx_cost_hr"] for i in result["fp16"]["instances"]]
+        assert costs == sorted(costs)


### PR DESCRIPTION
Adds cloud GPU instance suggestions (AWS, GCP, Azure) to the model command so users can find suitable cloud instances without leaving the CLI.

- `env-doctor model <name> --recommend` shows cheapest-first cloud instances per quantization level (FP16, INT4, etc.)
- `env-doctor model --vram <MB> --recommend` for direct VRAM lookup without specifying a model name
- MCP `model_check` tool accepts `recommend: true` to include cloud_recommendations in the result dict
- 17 instances across AWS, GCP, Azure in cloud_instances.json
- 15 unit tests for CloudRecommender (filtering, sorting, headroom)